### PR TITLE
fixes #2 (Text for ChatGPt output is not respecting line breaks)

### DIFF
--- a/qchatqpt.py
+++ b/qchatqpt.py
@@ -266,8 +266,12 @@ class qchatgpt:
 
                 last_ans = "AI: " + self.response['choices'][0]['text']
                 self.answers.append(last_ans)
-                cursor = self.dlg.chatgpt_ans.textCursor()
-                cursor.insertHtml('''<p><span style="background: #F7F7F8;">{} </span>'''.format(last_ans))
+                
+                # Initial implementation. Doesn't preserve newlines
+                #cursor = self.dlg.chatgpt_ans.textCursor()
+                #cursor.insertHtml('''<p><span style="background: #F7F7F8;">{} </span>'''.format(last_ans))
+                self.dlg.chatgpt_ans.insertPlainText(last_ans)
+                
                 self.dlg.chatgpt_ans.repaint()
                 self.dlg.question.setText('')
                 self.dlg.chatgpt_ans.verticalScrollBar().setValue(


### PR DESCRIPTION
This is a quick fix to Issue #2 , which is a fairly important one (as most ChatGPT usage within QGIS will probably be code). I am hoping that it does not break some other functionality, as I did not notice why you used the html formatting in this piece of code. Future implementation of syntax highlighting? I'd love to know you rationale and/or future plan on this.

Cheers!