### PR TITLE
Adding hint to install openai module on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@ Source: https://openai.com/
 
 ![https://github.com/Mariosmsk/QChatGPT/blob/main/example.png](https://github.com/Mariosmsk/QChatGPT/blob/main/example2.png)
 
+## Installation notes
+
+### macOS + QGIS 3
+
+* in a macOS shell window, run
+
+```
+/Applications/QGIS.app/Contents/MacOS/bin/python3 -m pip install openai
+```


### PR DESCRIPTION
Hi, 

could be a nice addition to the project README to include openai installtion process for major OSes

Proposing the macOS version with this PR