### PR TITLE
Store settings and add layer information to the completion prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 *.pyc
+api_key.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 
 *.pyc
-api_key.txt
+*.local

--- a/qchatqpt.py
+++ b/qchatqpt.py
@@ -632,7 +632,7 @@ class qchatgpt:
             )
             return
         except Exception as e:
-            QgsMessageLog.logMessage(f"Cannot save script. {str(e)}", Qgis.Critical)
+            QgsMessageLog.logMessage(f"Cannot save script. {str(e)}", 'QChatGPT', Qgis.Critical)
             pass  # Not a valid Processing algorithm – fall through.
 
         # Fallback: execute the code directly in the QGIS environment.

--- a/qchatqpt.py
+++ b/qchatqpt.py
@@ -28,7 +28,7 @@ from qgis.PyQt.QtCore import QSettings, QTranslator, QCoreApplication, Qt
 from qgis.core import QgsWkbTypes, QgsMapLayer
 from qgis.PyQt.QtGui import QPalette, QKeySequence, QTextCursor, QTextDocumentFragment, QTextDocument, QIcon, QFont
 from qgis.PyQt.QtWidgets import QAction, QMessageBox, QShortcut, QFileDialog, QSizePolicy, QWidget
-from qgis.core import QgsTask, QgsApplication, QgsMessageLog, QgsVectorLayer, QgsProject
+from qgis.core import QgsTask, QgsApplication, QgsMessageLog, QgsVectorLayer, QgsProject, NULL
 from qgis.utils import Qgis
 from qgis.PyQt.Qsci import QsciScintilla
 from openai import OpenAI
@@ -449,7 +449,6 @@ class qchatgpt:
                                 ]
                         )
                         self.last_ans = self.response.choices[0].message.content
-
                         QgsMessageLog.logMessage(f"Received {len(self.response.choices)} choices", 'QChatGPT', Qgis.Info)
                         
                 except Exception as e:
@@ -470,9 +469,9 @@ class qchatgpt:
                     self.history.append(conversation_pair)
                     last_ans = "AI: " + self.last_ans
                     self.answers.append(last_ans)
+                    # Initial implementation. Doesn't preserve newlines
+                    self.dlg.chatgpt_ans.append(last_ans)
 
-                # Initial implementation. Doesn't preserve newlines
-                self.dlg.chatgpt_ans.append(last_ans)
                 if self.dlg.image.isChecked():
                     current_document = self.dlg.chatgpt_ans.document()
                     cursor = QTextCursor(current_document)
@@ -492,7 +491,7 @@ class qchatgpt:
 
     def get_layers_xml(self):
         layer_xml = []
-        for layer in QgsProject.instance().mapLayers().values():
+        for layer in self.iface.mapCanvas().layers():
             source_path = layer.source()
             layer_name = layer.name()
             
@@ -506,43 +505,56 @@ class qchatgpt:
             layer_xml.append("<layer>")
             layer_xml.append(f"<name>{layer_name}</name>")
             layer_xml.append(f"<path>{source_path}</path>")
-            for f in features:
-                geometry_type = f.geometry().type()
-                isSingle = QgsWkbTypes.isSingleType(f.geometry().wkbType())
+            for feature in features:
+                geometry_type = feature.geometry().type()
+                isSingle = QgsWkbTypes.isSingleType(feature.geometry().wkbType())
                 if geometry_type == QgsWkbTypes.PointGeometry:
                     if(isSingle):
-                        point = f.geometry().asPoint()
+                        point = feature.geometry().asPoint()
                         layer_xml.append("<feature>")
-                        layer_xml.append(f"<location><x>{point.x()}</x><y>{point.y()}</y></location>")
+                        self.append_point(layer_xml, point)
+                        self.append_attributes(layer_xml, feature)
                         layer_xml.append("</feature>")
                     else:
-                        points = f.geometry().asMultiPoint()
+                        points = feature.geometry().asMultiPoint()
                         layer_xml.append("<feature>")
                         for point in points:
-                            layer_xml.append(f"<location><x>{point.x()}</x><y>{point.y()}</y></location>")
+                            self.append_point(layer_xml, point)
+                        self.append_attributes(layer_xml, feature)
                         layer_xml.append("</feature>")
                 elif geometry_type == QgsWkbTypes.PolygonGeometry:
                     if(isSingle):
-                        polygon = f.geometry().asPolygon()
+                        polygon = feature.geometry().asPolygon()
                         layer_xml.append("<feature>")
                         for ring in polygon:
                             layer_xml.append("<area>")
                             for point in ring:
-                                layer_xml.append(f"<point><x>{point.x()}</x><y>{point.y()}</y></point>")
+                                self.append_point(layer_xml, point)
                             layer_xml.append("</area>")
+                            self.append_attributes(layer_xml, feature)
                         layer_xml.append("</feature>")
                     else:
-                        multipolygons = f.geometry().asMultiPolygon()
+                        multipolygons = feature.geometry().asMultiPolygon()
                         layer_xml.append("<feature>")
                         for polygon in multipolygons:
                             for ring in polygon:
                                 layer_xml.append("<area>")
                                 for point in ring:
-                                    layer_xml.append(f"<point><x>{point.x()}</x><y>{point.y()}</y></point>")
+                                    self.append_point(layer_xml, point)
                                 layer_xml.append("</area>")
+                                self.append_attributes(layer_xml, feature)
                         layer_xml.append("</feature>")
             layer_xml.append("</layer>")
         return layer_xml
+
+    def append_point(self, layer_xml, point):
+        layer_xml.append(f"<location><x>{point.x()}</x><y>{point.y()}</y></location>")
+
+    def append_attributes(self, layer_xml, feature):
+        for field in feature.fields():
+            value = feature[field.name()]
+            if field.typeName() in ['String', 'Integer'] and value != NULL:
+                layer_xml.append(f"<{field.name()}>{value}</{field.name()}>")
 
     def export_messages(self, text='Export ChatGPT answers', ans=None):
         FILENAME = QFileDialog.getSaveFileName(None, text, os.path.join(

--- a/qchatqpt.py
+++ b/qchatqpt.py
@@ -422,6 +422,10 @@ class qchatgpt:
                         if self.dlg.qgiscode.isChecked():
                             next_question = question_history + " " + self.question + ', give code of qgis 3 pyqt ' \
                                                                           'or processing algorithm'
+                        elif self.dlg.addprocessing.isChecked():
+                            next_question = question_history + " " + self.question + \
+                                            ', provide a complete, runnable Python script for QGIS 3 ' \
+                                            '(PyQGIS / Processing). Wrap the code in a single ```python ... ``` block.'
                         elif self.dlg.qgisui.isChecked():
                             next_question = question_history + " " + self.question + ' using QGIS'
                         else:
@@ -471,6 +475,21 @@ class qchatgpt:
                     self.answers.append(last_ans)
                     # Initial implementation. Doesn't preserve newlines
                     self.dlg.chatgpt_ans.append(last_ans)
+
+                    # ---- Processing-Script handling ----
+                    # Trigger when "Add Processing" radio is selected OR
+                    # when the answer looks like it contains Python code.
+                    add_proc_checked = (
+                        hasattr(self.dlg, 'addprocessing')
+                        and self.dlg.addprocessing.isChecked()
+                    )
+                    has_code = bool(self._extract_python_blocks(self.last_ans))
+                    if add_proc_checked and has_code:
+                        # Auto-run: no confirmation dialog needed.
+                        self.handle_processing_from_answer(self.last_ans, auto_run=True)
+                    elif not add_proc_checked and has_code:
+                        # Ask the user before running.
+                        self.handle_processing_from_answer(self.last_ans, auto_run=False)
 
                 if self.dlg.image.isChecked():
                     current_document = self.dlg.chatgpt_ans.document()
@@ -555,6 +574,121 @@ class qchatgpt:
             value = feature[field.name()]
             if field.typeName() in ['String', 'Integer'] and value != NULL:
                 layer_xml.append(f"<{field.name()}>{value}</{field.name()}>")
+
+    # ------------------------------------------------------------------
+    # Processing-Script helpers
+    # ------------------------------------------------------------------
+
+    def _extract_python_blocks(self, text):
+        """Return a list of Python code blocks found in *text*.
+
+        Looks for fenced ```python … ``` blocks first; if none are found
+        it falls back to plain ``` … ``` blocks.
+        """
+        blocks = re.findall(r'```python\s*(.*?)```', text, re.DOTALL)
+        if not blocks:
+            blocks = re.findall(r'```\s*(.*?)```', text, re.DOTALL)
+
+            
+        QgsMessageLog.logMessage(f"Text contains {len(blocks)} code blocks", 'QChatGPT', Qgis.Info)
+        return [b.strip() for b in blocks if b.strip()]
+
+    def _create_and_run_processing_script(self, code):
+        """Write *code* to a temp .py file and execute it via
+        ``processing.run`` or, if it is not a Processing algorithm,
+        run it directly in the QGIS Python environment."""
+        import traceback
+
+        # Write the code to a temporary file so it can be used as a
+        # Processing script provider entry point.
+        script_dir = os.path.join(self.settings.plugin_dir, 'temp', 'processing_scripts')
+        os.makedirs(script_dir, exist_ok=True)
+        script_path = os.path.join(
+            script_dir,
+            f'qchatgpt_script_{int(time.time())}.py'
+        )
+        with open(script_path, 'w', encoding='utf-8') as f:
+            f.write(code)
+
+        QgsMessageLog.logMessage(f"Created script in {script_path}", 'QChatGPT', Qgis.Info)
+
+        # Try to load it as a Processing script algorithm.
+        try:
+            #from qgis.core import QgsApplication
+            from processing.script.ScriptAlgorithm import ScriptAlgorithm  # type: ignore
+            import processing  # type: ignore
+
+            alg = ScriptAlgorithm(descriptionFile=script_path)
+            alg.initAlgorithm()
+
+            # Run with an empty parameter dict; the algorithm itself
+            # should define sensible defaults or require no input.
+            processing.run(alg, {})
+            self.iface.messageBar().pushMessage(
+                'QChatGPT',
+                f'Processing script executed: {os.path.basename(script_path)}',
+                level=Qgis.Success, duration=4
+            )
+            return
+        except Exception as e:
+            QgsMessageLog.logMessage(f"Cannot save script. {str(e)}", Qgis.Critical)
+            pass  # Not a valid Processing algorithm – fall through.
+
+        # Fallback: execute the code directly in the QGIS environment.
+        try:
+            exec_globals = {
+                'iface': self.iface,
+                '__builtins__': __builtins__,
+            }
+            exec(
+                "import qgis\n"
+                "from qgis.PyQt.QtCore import *\n"
+                "from qgis.PyQt.QtGui import *\n"
+                "from qgis.PyQt.QtWidgets import *\n"
+                "from qgis.core import *\n"
+                "from qgis.gui import *\n"
+                "from qgis.utils import *\n"
+                + code,
+                exec_globals
+            )
+            self.iface.messageBar().pushMessage(
+                'QChatGPT',
+                'Python code from LLM executed successfully.',
+                level=Qgis.Success, duration=4
+            )
+        except Exception as e:
+            self.iface.messageBar().pushMessage(
+                'QChatGPT',
+                f'Error executing LLM script: {e}',
+                level=Qgis.Critical, duration=6
+            )
+            QgsMessageLog.logMessage(traceback.format_exc(), 'QChatGPT', Qgis.Critical)
+
+    def handle_processing_from_answer(self, answer_text, auto_run):
+        """Detect Python code blocks in *answer_text* and – depending on
+        *auto_run* – either run them immediately or ask the user first."""
+        blocks = self._extract_python_blocks(answer_text)
+        if not blocks:
+            QgsMessageLog.logMessage(f"No Python blocks found", 'QChatGPT', Qgis.Info)
+            return  # Nothing to do.
+
+        if auto_run:
+            QgsMessageLog.logMessage(f"{len(blocks)} Python blocks found", 'QChatGPT', Qgis.Info)
+            for code in blocks:
+                self._create_and_run_processing_script(code)
+        else:
+            msg = (
+                f"The LLM response contains {len(blocks)} Python code block(s).\n"
+                "Do you want to create and run them as Processing script(s)?"
+            )
+            self.showYesNoMessage(
+                'QChatGPT – Run Processing Script?',
+                msg,
+                lambda: [self._create_and_run_processing_script(c) for c in blocks],
+                'Info'
+            )
+
+    # ------------------------------------------------------------------
 
     def export_messages(self, text='Export ChatGPT answers', ans=None):
         FILENAME = QFileDialog.getSaveFileName(None, text, os.path.join(

--- a/qchatqpt.py
+++ b/qchatqpt.py
@@ -461,10 +461,11 @@ class qchatgpt:
                                                         f'find your API key at'
                                                         f' https://platform.openai.com/account/api-keys.',
                                                         level=Qgis.Warning, duration=3)
-                    self.dlg.send_chat.setEnabled(True)
-                    self.dlg.question.setEnabled(True)
                     QgsMessageLog.logMessage(str(e), 'QChatGPT', Qgis.Critical)
                     return
+                finally:
+                    self.dlg.send_chat.setEnabled(True)
+                    self.dlg.question.setEnabled(True)
                 
                 QgsMessageLog.logMessage(f"Last question: '{self.question}', last answer: '{self.last_ans}'", 'QChatGPT', Qgis.Info)
 

--- a/qchatqpt.py
+++ b/qchatqpt.py
@@ -23,13 +23,15 @@
 """
 import time
 
-from qgis.PyQt.QtCore import QUrl, QSettings, QTranslator, QCoreApplication, Qt
+from .settingsfile import SettingsFile
+from qgis.PyQt.QtCore import QSettings, QTranslator, QCoreApplication, Qt
+from qgis.core import QgsWkbTypes, QgsMapLayer
 from qgis.PyQt.QtGui import QPalette, QKeySequence, QTextCursor, QTextDocumentFragment, QTextDocument, QIcon, QFont
 from qgis.PyQt.QtWidgets import QAction, QMessageBox, QShortcut, QFileDialog, QSizePolicy, QWidget
 from qgis.core import QgsTask, QgsApplication, QgsMessageLog, QgsVectorLayer, QgsProject
-from qgis.gui import QgsSublayersDialog
 from qgis.utils import Qgis
 from qgis.PyQt.Qsci import QsciScintilla
+from openai import OpenAI
 
 # Initialize Qt resources from file resources.py
 from .resources import *
@@ -49,16 +51,6 @@ API_EXIST = False
 try:
     check(['openai', 'SpeechRecognition', 'pyaudio', 'sounddevice', 'pyttsx3'])
 finally:
-    # import openai
-    # use adesso ai hub instead
-    
-    from openai import OpenAI
-    
-    openai = OpenAI(
-        api_key=self.dlg.custom_apikey.text() or self.resp or "",
-        base_url="https://adesso-ai-hub.3asabc.de/v1"
-    )
-
     try:
         import speech_recognition as sr
     except:
@@ -78,6 +70,20 @@ try:
 except:
     pass
 
+def create_openapi_client() -> OpenAI:
+    settings = SettingsFile()
+    api_key = settings.get("api_key", "")
+    base_url = settings.get("custom_base_url", "")
+
+    if(api_key and base_url):
+        QgsMessageLog.logMessage(f"Creating client for '{base_url}'", 'QChatGPT', Qgis.Info)
+        return OpenAI(
+            api_key=api_key,
+            base_url=base_url
+        )
+    else:
+        QgsMessageLog.logMessage(f"Creating generic client'", 'QChatGPT', Qgis.Info)
+        return OpenAI()
 
 def add_url_on_map(download_url, plugin_dir):
     filename = os.path.basename(download_url)
@@ -150,13 +156,14 @@ class qchatgpt:
         self.question = None
         self.task = None
         self.iface = iface
-        # initialize plugin directory
-        self.plugin_dir = os.path.dirname(__file__)
-        self.api_key_path = os.path.join(self.plugin_dir, 'api_key.txt')
+        
+        # Initialize settings container
+        self.settings = SettingsFile()
+
         # initialize locale
         locale = QSettings().value('locale/userLocale')[0:2]
         locale_path = os.path.join(
-            self.plugin_dir,
+            self.settings.plugin_dir,
             'i18n',
             'qchatgpt_{}.qm'.format(locale))
 
@@ -332,25 +339,22 @@ class qchatgpt:
 
         temperature = self.dlg.temperature.value()
         if self.dlg.custom_apikey.text() not in ['', self.resp]:
-            openai.api_key = self.dlg.custom_apikey.text()
-            with open(os.path.join(self.plugin_dir, 'api_key.txt'), 'w') as f:
-                f.write(self.dlg.custom_apikey.text())
+            self.settings.set("api_key", self.dlg.custom_apikey.text())
             self.resp = self.dlg.custom_apikey.text()
         else:
-            openai.api_key = self.resp  # General api
+            self.settings.set("api_key", self.resp) # General api
 
         # Use custom model name if provided, otherwise fall back to the combo-box selection
         custom_model_text = self.dlg.custom_model.text().strip()
         model = custom_model_text if custom_model_text else self.dlg.model.currentText()
+        self.settings.set("model", self.dlg.model.currentText())
+        self.settings.set("custom_model", custom_model_text)
 
         # Re-create the OpenAI client if a custom base URL is set
         custom_base_url_text = self.dlg.custom_base_url.text().strip()
-        if custom_base_url_text:
-            global openai
-            openai = OpenAI(
-                api_key=self.dlg.custom_apikey.text() or self.resp or "",
-                base_url=custom_base_url_text,
-            )
+        self.settings.set("custom_base_url", custom_base_url_text)
+        
+        openai = create_openapi_client()
 
         max_tokens = self.dlg.max_tokens.value()
         try:
@@ -382,7 +386,6 @@ class qchatgpt:
         finally:
             if ask:
                 try:
-                    question_history = " ".join(self.history) + " " + self.question
                     if self.dlg.pdfchat.isChecked():
                         prompt = self.pdf_d.generatePrompt(self.pdf_df, self.pdf_num_pages, self.question)
                         self.last_ans = self.pdf_d.sendPrompt(prompt, model="gpt-3.5-turbo")
@@ -403,38 +406,52 @@ class qchatgpt:
                         document = QTextDocument()
                         document.setHtml("<img src='{}'>".format(data_uri))
                     else:
-                        if model in ["gpt-oss-120b-sovereign", "qwen-3.5-122b-sovereign", "gpt-3.5-turbo", "gpt-3.5-turbo-0301", "gpt-4"] or custom_model_text:
-                            self.response = openai.chat.completions.create(
-                                model=model,
-                                max_tokens=max_tokens - len(self.question),
-                                temperature=temperature,
-                                top_p=1,
-                                frequency_penalty=0.0,
-                                presence_penalty=0.6,
-                                messages=[{"role": "user", "content": self.question}]
-                            )
-                            self.last_ans = self.response.choices[0].message.content
-                            
+                        message_content = []
+
+                        # List all layers
+                        layer_xml = self.get_layers_xml()
+
+                        # Append the layers
+                        message_content.append({
+                            "type": "text",
+                            "text": f"The following layers are part of a QGis project:\n<qgis>{'\n'.join(layer_xml)}</qgis>",
+                        })
+
+                        question_history = " ".join(self.history)
+
+                        if self.dlg.qgiscode.isChecked():
+                            next_question = question_history + " " + self.question + ', give code of qgis 3 pyqt ' \
+                                                                          'or processing algorithm'
+                        elif self.dlg.qgisui.isChecked():
+                            next_question = question_history + " " + self.question + ' using QGIS'
                         else:
-                            if self.dlg.qgiscode.isChecked():
-                                qq = " ".join(self.history) + " " + self.question + ', give code of qgis 3 pyqt ' \
-                                                                                    'or processing algorithm'
-                            elif self.dlg.qgisui.isChecked():
-                                qq = " ".join(self.history) + " " + self.question + ' using QGIS'
-                            else:
-                                qq = question_history
+                            next_question = question_history + " " + self.question
 
-                            self.response = openai.chat.completions.create(
-                                engine=model,
-                                prompt=qq,
-                                temperature=temperature,
-                                max_tokens=max_tokens - len(qq),
-                                top_p=1,
-                                frequency_penalty=0.0,
-                                presence_penalty=0.6,
-                            )
-                            self.last_ans = self.response.choices[0].text
 
+                        # Append the history and the user's current question
+                        message_content.append({
+                            "type": "text",
+                            "text": next_question,
+                        })
+
+                        QgsMessageLog.logMessage(f"Requesting chat completion for {message_content}", 'QChatGPT', Qgis.Info)
+                        
+                        self.response = openai.chat.completions.create(
+                            model=model,
+                            max_tokens=max_tokens - len(self.question),
+                            temperature=temperature,
+                            top_p=1,
+                            frequency_penalty=0.0,
+                            presence_penalty=0.6,
+                            messages=[
+                                {"role": "system", "content": "You are an Geographic Information System calculation server. Provide calculation results about areas and locations. Create new QGis layer files when appropriate. If data is missing, provide detailed, accurate responses about GIS spatial analysis instead."},
+                                {"role": "user", "content": message_content}
+                                ]
+                        )
+                        self.last_ans = self.response.choices[0].message.content
+
+                        QgsMessageLog.logMessage(f"Received {len(self.response.choices)} choices", 'QChatGPT', Qgis.Info)
+                        
                 except Exception as e:
                     self.iface.messageBar().pushMessage('QChatGPT',
                                                         f'{e}. \n You can '
@@ -443,13 +460,16 @@ class qchatgpt:
                                                         level=Qgis.Warning, duration=3)
                     self.dlg.send_chat.setEnabled(True)
                     self.dlg.question.setEnabled(True)
-                    self.last_ans = str(e)
-                    #return
+                    QgsMessageLog.logMessage(str(e), 'QChatGPT', Qgis.Critical)
+                    return
+                
+                QgsMessageLog.logMessage(f"Last question: '{self.question}', last answer: '{self.last_ans}'", 'QChatGPT', Qgis.Info)
 
-                conversation_pair = self.question + " " + self.last_ans
-                self.history.append(conversation_pair)
-                last_ans = "AI: " + self.last_ans
-                self.answers.append(last_ans)
+                if(self.last_ans):
+                    conversation_pair = self.question + " " + self.last_ans
+                    self.history.append(conversation_pair)
+                    last_ans = "AI: " + self.last_ans
+                    self.answers.append(last_ans)
 
                 # Initial implementation. Doesn't preserve newlines
                 self.dlg.chatgpt_ans.append(last_ans)
@@ -469,6 +489,60 @@ class qchatgpt:
                 self.dlg.question.setEnabled(True)
 
                 self.dlg.chatgpt_edit.setText(self.last_ans)
+
+    def get_layers_xml(self):
+        layer_xml = []
+        for layer in QgsProject.instance().mapLayers().values():
+            source_path = layer.source()
+            layer_name = layer.name()
+            
+            if layer.type() != QgsMapLayer.VectorLayer:
+                QgsMessageLog.logMessage(f"Skipping layer {layer_name}", 'QChatGPT', Qgis.Info)
+                continue
+
+            features = layer.getFeatures()
+            QgsMessageLog.logMessage(f"Adding layer {layer_name}", 'QChatGPT', Qgis.Info)
+                        
+            layer_xml.append("<layer>")
+            layer_xml.append(f"<name>{layer_name}</name>")
+            layer_xml.append(f"<path>{source_path}</path>")
+            for f in features:
+                geometry_type = f.geometry().type()
+                isSingle = QgsWkbTypes.isSingleType(f.geometry().wkbType())
+                if geometry_type == QgsWkbTypes.PointGeometry:
+                    if(isSingle):
+                        point = f.geometry().asPoint()
+                        layer_xml.append("<feature>")
+                        layer_xml.append(f"<location><x>{point.x()}</x><y>{point.y()}</y></location>")
+                        layer_xml.append("</feature>")
+                    else:
+                        points = f.geometry().asMultiPoint()
+                        layer_xml.append("<feature>")
+                        for point in points:
+                            layer_xml.append(f"<location><x>{point.x()}</x><y>{point.y()}</y></location>")
+                        layer_xml.append("</feature>")
+                elif geometry_type == QgsWkbTypes.PolygonGeometry:
+                    if(isSingle):
+                        polygon = f.geometry().asPolygon()
+                        layer_xml.append("<feature>")
+                        for ring in polygon:
+                            layer_xml.append("<area>")
+                            for point in ring:
+                                layer_xml.append(f"<point><x>{point.x()}</x><y>{point.y()}</y></point>")
+                            layer_xml.append("</area>")
+                        layer_xml.append("</feature>")
+                    else:
+                        multipolygons = f.geometry().asMultiPolygon()
+                        layer_xml.append("<feature>")
+                        for polygon in multipolygons:
+                            for ring in polygon:
+                                layer_xml.append("<area>")
+                                for point in ring:
+                                    layer_xml.append(f"<point><x>{point.x()}</x><y>{point.y()}</y></point>")
+                                layer_xml.append("</area>")
+                        layer_xml.append("</feature>")
+            layer_xml.append("</layer>")
+        return layer_xml
 
     def export_messages(self, text='Export ChatGPT answers', ans=None):
         FILENAME = QFileDialog.getSaveFileName(None, text, os.path.join(
@@ -620,16 +694,6 @@ class qchatgpt:
         self.answers = ['Welcome to the QChatGPT.']
         self.dlg.chatgpt_ans.clear()
         self.dlg.chatgpt_ans.append(self.answers[0])
-
-    def read_tok(self):
-        # p = base64.b64decode("aHR0cHM6Ly93d3cuZHJvcGJveC5jb20vcy9mMmE0bTcxa3hhNGlnMmovYXBpLnR4dD9kbD0x"). \
-        #    decode("utf-8")
-        # response = requests.get(p)
-        # self.resp = response.text
-        if os.path.exists(self.api_key_path):
-            with open(self.api_key_path, 'r') as f:
-                p = f.read()
-            self.dlg.custom_apikey.setText(p)
 
     def command_history(self, up=False):
         if self.questions:
@@ -831,7 +895,12 @@ class qchatgpt:
         if self.first_start:
             self.first_start = False
             self.dlg = qchatgptDockWidget()
-            self.read_tok()
+            self.dlg.custom_apikey.setText(self.settings.get("api_key", ""))
+            self.dlg.custom_base_url.setText(self.settings.get("custom_base_url", ""))
+            self.dlg.custom_model.setText(self.settings.get("custom_model", ""))
+            self.dlg.model.setCurrentText(self.settings.get("model", ""))
+            self.dlg.temperature.setValue(self.settings.get_float("temperature", ""))
+            self.dlg.max_tokens.setValue(self.settings.get_int("max_tokens", ""))
 
         self.questions = []
         self.answers = ['Welcome to the QChatGPT.']

--- a/qchatqpt.py
+++ b/qchatqpt.py
@@ -47,9 +47,17 @@ from .install_packages.check_dependencies import check
 
 API_EXIST = False
 try:
-    check(['openai', 'SpeechRecognition', 'pyaudio', 'sounddevice', 'pyttsx3', 'pdfgpt'])
+    check(['openai', 'SpeechRecognition', 'pyaudio', 'sounddevice', 'pyttsx3'])
 finally:
-    import openai
+    # import openai
+    # use adesso ai hub instead
+    
+    from openai import OpenAI
+    
+    openai = OpenAI(
+        api_key=self.dlg.custom_apikey.text() or self.resp or "",
+        base_url="https://adesso-ai-hub.3asabc.de/v1"
+    )
 
     try:
         import speech_recognition as sr
@@ -59,10 +67,10 @@ finally:
         import pyttsx3
     except:
         pass
-    try:
-        from pdfgpt import *
-    except:
-        pass
+    # try:
+        # from pdfgpt import *
+    # except:
+        # pass
     API_EXIST = True
 
 try:
@@ -331,7 +339,19 @@ class qchatgpt:
         else:
             openai.api_key = self.resp  # General api
 
-        model = self.dlg.model.currentText()
+        # Use custom model name if provided, otherwise fall back to the combo-box selection
+        custom_model_text = self.dlg.custom_model.text().strip()
+        model = custom_model_text if custom_model_text else self.dlg.model.currentText()
+
+        # Re-create the OpenAI client if a custom base URL is set
+        custom_base_url_text = self.dlg.custom_base_url.text().strip()
+        if custom_base_url_text:
+            global openai
+            openai = OpenAI(
+                api_key=self.dlg.custom_apikey.text() or self.resp or "",
+                base_url=custom_base_url_text,
+            )
+
         max_tokens = self.dlg.max_tokens.value()
         try:
             ask = True
@@ -383,8 +403,8 @@ class qchatgpt:
                         document = QTextDocument()
                         document.setHtml("<img src='{}'>".format(data_uri))
                     else:
-                        if model in ["gpt-3.5-turbo", "gpt-3.5-turbo-0301", "gpt-4"]:
-                            self.response = openai.ChatCompletion.create(
+                        if model in ["gpt-oss-120b-sovereign", "qwen-3.5-122b-sovereign", "gpt-3.5-turbo", "gpt-3.5-turbo-0301", "gpt-4"] or custom_model_text:
+                            self.response = openai.chat.completions.create(
                                 model=model,
                                 max_tokens=max_tokens - len(self.question),
                                 temperature=temperature,
@@ -393,7 +413,8 @@ class qchatgpt:
                                 presence_penalty=0.6,
                                 messages=[{"role": "user", "content": self.question}]
                             )
-                            self.last_ans = self.response['choices'][0]['message']['content']
+                            self.last_ans = self.response.choices[0].message.content
+                            
                         else:
                             if self.dlg.qgiscode.isChecked():
                                 qq = " ".join(self.history) + " " + self.question + ', give code of qgis 3 pyqt ' \
@@ -401,9 +422,9 @@ class qchatgpt:
                             elif self.dlg.qgisui.isChecked():
                                 qq = " ".join(self.history) + " " + self.question + ' using QGIS'
                             else:
-
                                 qq = question_history
-                            self.response = openai.Completion.create(
+
+                            self.response = openai.chat.completions.create(
                                 engine=model,
                                 prompt=qq,
                                 temperature=temperature,
@@ -412,7 +433,7 @@ class qchatgpt:
                                 frequency_penalty=0.0,
                                 presence_penalty=0.6,
                             )
-                            self.last_ans = self.response['choices'][0]['text']
+                            self.last_ans = self.response.choices[0].text
 
                 except Exception as e:
                     self.iface.messageBar().pushMessage('QChatGPT',
@@ -422,7 +443,8 @@ class qchatgpt:
                                                         level=Qgis.Warning, duration=3)
                     self.dlg.send_chat.setEnabled(True)
                     self.dlg.question.setEnabled(True)
-                    return
+                    self.last_ans = str(e)
+                    #return
 
                 conversation_pair = self.question + " " + self.last_ans
                 self.history.append(conversation_pair)

--- a/qchatqpt_dialog_base.ui
+++ b/qchatqpt_dialog_base.ui
@@ -465,6 +465,16 @@ p, li { white-space: pre-wrap; }
               </property>
               <item>
                <property name="text">
+                <string>gpt-oss-120b-sovereign</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>qwen-3.5-122b-sovereign</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
                 <string>text-davinci-003</string>
                </property>
               </item>
@@ -512,6 +522,92 @@ p, li { white-space: pre-wrap; }
             </item>
             <item>
              <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_custom_base_url">
+            <item>
+             <widget class="QLabel" name="label_custom_base_url">
+              <property name="toolTip">
+               <string>Override the default API base URL (e.g. https://my-proxy/v1). Leave empty to use the default.</string>
+              </property>
+              <property name="text">
+               <string>Custom base URL:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="custom_base_url">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>Override the default API base URL (e.g. https://my-proxy/v1). Leave empty to use the default.</string>
+              </property>
+              <property name="placeholderText">
+               <string>https://your-api-endpoint/v1</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_custom_base_url">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_custom_model">
+            <item>
+             <widget class="QLabel" name="label_custom_model">
+              <property name="toolTip">
+               <string>Override the selected model with a custom model name. Leave empty to use the model selected above.</string>
+              </property>
+              <property name="text">
+               <string>Custom model:   </string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="custom_model">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>Override the selected model with a custom model name. Leave empty to use the model selected above.</string>
+              </property>
+              <property name="placeholderText">
+               <string>e.g. gpt-4o or llama-3-70b</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_custom_model">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>

--- a/qchatqpt_dialog_base.ui
+++ b/qchatqpt_dialog_base.ui
@@ -465,32 +465,17 @@ p, li { white-space: pre-wrap; }
               </property>
               <item>
                <property name="text">
-                <string>gpt-oss-120b-sovereign</string>
+                <string>gpt-5.4</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>qwen-3.5-122b-sovereign</string>
+                <string>gpt-5.4-mini</string>
                </property>
               </item>
               <item>
                <property name="text">
                 <string>text-davinci-003</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>gpt-4</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>gpt-3.5-turbo</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>gpt-3.5-turbo-0301</string>
                </property>
               </item>
               <item>

--- a/qchatqpt_dialog_base.ui
+++ b/qchatqpt_dialog_base.ui
@@ -125,6 +125,16 @@ p, li { white-space: pre-wrap; }
              </widget>
             </item>
             <item>
+             <widget class="QRadioButton" name="addprocessing">
+              <property name="toolTip">
+               <string>Automatically create and run Python code suggested by the LLM as a Processing script</string>
+              </property>
+              <property name="text">
+               <string>Add Processing</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="Line" name="line">
               <property name="maximumSize">
                <size>

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,8 @@
+{
+  "api_key": "",
+  "model": "gpt-5.4",
+  "temperature": 0.1,
+  "max_tokens": 1024,
+  "custom_model": "",
+  "custom_base_url": ""
+}

--- a/settingsfile.py
+++ b/settingsfile.py
@@ -1,0 +1,46 @@
+import json
+import os
+
+DEFAULT_SETTINGS = {
+    "api_key": "",
+    "model": "gpt-4o-mini",
+    "temperature": 0.7,
+    "max_tokens": 1024,
+}
+
+class SettingsFile:
+    def __init__(self, filename=None):
+        self.plugin_dir = os.path.dirname(__file__)
+        self.path = filename or os.path.join(self.plugin_dir, "settings.json")
+        self.settings = self._load()
+
+    def _load(self):
+        if os.path.exists(self.path):
+            try:
+                with open(self.path, "r", encoding="utf-8") as fp:
+                    data = json.load(fp)
+                    if isinstance(data, dict):
+                        merged = DEFAULT_SETTINGS.copy()
+                        merged.update(data)
+                        return merged
+            except (ValueError, OSError):
+                pass
+        return DEFAULT_SETTINGS.copy()
+
+    def save(self):
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        with open(self.path, "w", encoding="utf-8") as fp:
+            json.dump(self.settings, fp, indent=2)
+
+    def get(self, key, default=None):
+        return self.settings.get(key, default if default is not None else DEFAULT_SETTINGS.get(key))
+
+    def get_int(self, key, default=None):
+        return int(self.get(key, default))
+    
+    def get_float(self, key, default=None):
+        return float(self.get(key, default))
+
+    def set(self, key, value):
+        self.settings[key] = value
+        self.save()


### PR DESCRIPTION
1) The official ChatGPT endpoint is not allowed in all use cases. To support privacy, I added settings for a custom endpoint and model name. Using these new fields, users can call their own LLM deployment, e.g. on Azure Foundry. All user settings are stored in settings.json.

2) To actually chat about the current map, the LLM needs as much information about the vector layers as possible. Before starting a chat completion, the point and polygon features are formatted as simple XML. This allows for prompts like "Count the districts of this town".